### PR TITLE
Nova-98: Automate Packaging

### DIFF
--- a/pack.ps1
+++ b/pack.ps1
@@ -1,0 +1,234 @@
+param(
+  [Parameter(Mandatory=$true)][string]$Version,
+  [Parameter(Mandatory=$true)][string]$PackageRepoPath,
+  [string]$BaseBranch = "main",
+  [string]$BranchName = "",
+  [switch]$ForceBranch,
+  [switch]$TagRelease,
+  [string]$PackageName    = "com.gyoudnova.handrecognition",
+  [string]$DisplayName    = "Hand Recognition",
+  [string]$Description    = "This is the package for hand recognition project created by Gyoud Nova",
+  [string]$UnityVersion   = "6000.0",
+  [string]$UnityRelease   = "39f1",
+  [string]$AuthorName     = "Gyoud Nova",
+  [switch]$OverrideCoreMetadata,
+  [switch]$RebuildSamples
+)
+
+$ErrorActionPreference = "Stop"
+if ($Version -match '^[vV](.+)$') { $Version = $Matches[1] }
+if (-not $BranchName -or [string]::IsNullOrWhiteSpace($BranchName)) { $BranchName = "release-v$Version" }
+
+function Require($name) { if (-not (Get-Command $name -ErrorAction SilentlyContinue)) { throw "Missing dependency in PATH: $name" } }
+Require git
+
+$ScriptDir   = Split-Path -Parent $MyInvocation.MyCommand.Path
+$ProjectRoot = & git -C $ScriptDir rev-parse --show-toplevel 2>$null
+if (-not $ProjectRoot) { $ProjectRoot = (Resolve-Path $ScriptDir).Path }
+
+if (-not (Test-Path -LiteralPath $PackageRepoPath)) { throw "PackageRepoPath '$PackageRepoPath' not found." }
+$PackageRepoPath = (Resolve-Path -LiteralPath $PackageRepoPath).Path
+
+$projRootN = [IO.Path]::GetFullPath($ProjectRoot + [IO.Path]::DirectorySeparatorChar)
+$destRootN = [IO.Path]::GetFullPath($PackageRepoPath + [IO.Path]::DirectorySeparatorChar)
+if ($destRootN.StartsWith($projRootN, [System.StringComparison]::OrdinalIgnoreCase)) { throw "Package repo '$destRootN' cannot be inside dev repo '$projRootN'." }
+
+Write-Host "==> Packing $PackageName v$Version"
+Write-Host "Dev repo:       $ProjectRoot"
+Write-Host "Package repo:   $PackageRepoPath"
+Write-Host "Base branch:    $BaseBranch"
+Write-Host "Package branch: $BranchName"
+
+if (-not (Test-Path (Join-Path $PackageRepoPath ".git"))) { throw "ERROR: $PackageRepoPath is not a git repo." }
+
+Push-Location $PackageRepoPath
+git fetch origin | Out-Null
+git checkout $BaseBranch | Out-Null
+git pull --ff-only | Out-Null
+$remoteExists = -not [string]::IsNullOrWhiteSpace((git ls-remote --heads origin $BranchName))
+if ($remoteExists -and -not $ForceBranch) { Pop-Location; throw "Remote branch '$BranchName' already exists. Re-run with -ForceBranch to overwrite." }
+if ((git branch --list $BranchName)) { git branch -D $BranchName | Out-Null }
+git checkout -B $BranchName $BaseBranch | Out-Null
+if (git status --porcelain) { Pop-Location; throw "ERROR: package repo has uncommitted changes." }
+Get-ChildItem -LiteralPath $PackageRepoPath -Force | Where-Object { $_.Name -ne ".git" } | Remove-Item -Recurse -Force -ErrorAction Stop
+Pop-Location
+
+function New-Dir([string]$Path) { if (-not (Test-Path -LiteralPath $Path)) { New-Item -ItemType Directory -Force -Path $Path | Out-Null } }
+function New-GuidHex { ([guid]::NewGuid().ToString("N")) }
+function Write-FolderMeta([string]$FolderPath) {
+  $metaPath = "$FolderPath.meta"
+  if (Test-Path -LiteralPath $metaPath) { return }
+  $guid = New-GuidHex
+@"
+fileFormatVersion: 2
+guid: $guid
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+"@ | Out-File -FilePath $metaPath -Encoding ascii
+}
+function Write-TextMeta([string]$FilePath) {
+  $metaPath = "$FilePath.meta"
+  if (Test-Path -LiteralPath $metaPath) { return }
+  $guid = New-GuidHex
+@"
+fileFormatVersion: 2
+guid: $guid
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+"@ | Out-File -FilePath $metaPath -Encoding ascii
+}
+function Copy-Or-Make-FolderMeta([string]$SrcFolder, [string]$DstFolder) {
+  $srcParent = Split-Path -Parent $SrcFolder
+  $srcLeaf   = Split-Path -Leaf $SrcFolder
+  $srcMeta   = Join-Path $srcParent ($srcLeaf + ".meta")
+  $dstMeta   = "$DstFolder.meta"
+  if (Test-Path -LiteralPath $srcMeta) { Copy-Item -LiteralPath $srcMeta -Destination $dstMeta -Force } else { Write-FolderMeta $DstFolder }
+}
+function Copy-DirContents {
+  param(
+    [Parameter(Mandatory=$true)][string]$From,
+    [Parameter(Mandatory=$true)][string]$To,
+    [string[]]$ExcludeChildNames = @()
+  )
+  if (-not (Test-Path -LiteralPath $From -PathType Container)) { Write-Host "SKIP missing: $From"; return }
+  New-Dir $To
+  Get-ChildItem -LiteralPath $From -Force | ForEach-Object {
+    if ($ExcludeChildNames -contains $_.Name) { return }
+    if ($_.Extension -ieq ".meta") {
+      $base = [IO.Path]::GetFileNameWithoutExtension($_.Name)
+      if ($ExcludeChildNames -contains $base) { return }
+    }
+    $dest = Join-Path $To $_.Name
+    Copy-Item -LiteralPath $_.FullName -Destination $dest -Recurse -Force -ErrorAction Stop
+  }
+}
+function Copy-TreeTo {
+  param([Parameter(Mandatory=$true)][string]$From, [Parameter(Mandatory=$true)][string]$To)
+  if (-not (Test-Path -LiteralPath $From -PathType Container)) { Write-Host "SKIP missing: $From"; return }
+  New-Dir $To
+  Get-ChildItem -LiteralPath $From -Force | ForEach-Object {
+    $dest = Join-Path $To $_.Name
+    Copy-Item -LiteralPath $_.FullName -Destination $dest -Recurse -Force -ErrorAction Stop
+  }
+}
+
+$Assets               = Join-Path $ProjectRoot "Assets"
+$Src_Scripts          = Join-Path $Assets "Scripts"
+$Src_Images           = Join-Path $Assets "Images"
+$Src_Prefabs          = Join-Path $Assets "Prefabs"
+$Src_Samples          = Join-Path $Assets "Samples"
+$Src_Streaming        = Join-Path $Assets "StreamingAssets"
+$Src_Tests            = Join-Path $Assets "Tests"
+$Src_UIToolkit        = Join-Path $Assets "UI Toolkit"
+
+$Dst_Editor           = Join-Path $PackageRepoPath "Editor"
+$Dst_Images           = Join-Path $PackageRepoPath "Images"
+$Dst_Runtime          = Join-Path $PackageRepoPath "Runtime"
+$Dst_Runtime_Prefabs  = Join-Path $Dst_Runtime "Prefabs"
+$Dst_Samples          = Join-Path $PackageRepoPath "Samples~"
+$Dst_Streaming        = Join-Path $PackageRepoPath "StreamingAssets"
+$Dst_Tests            = Join-Path $PackageRepoPath "Tests"
+$Dst_UIToolkit        = Join-Path $PackageRepoPath "UI Toolkit"
+
+Copy-DirContents -From $Src_Scripts -To $Dst_Editor -ExcludeChildNames @("Dev Utilities")
+Copy-Or-Make-FolderMeta -SrcFolder $Src_Scripts -DstFolder $Dst_Editor
+Copy-TreeTo -From $Src_Images -To $Dst_Images
+Copy-Or-Make-FolderMeta -SrcFolder $Src_Images -DstFolder $Dst_Images
+New-Dir $Dst_Runtime
+Write-FolderMeta $Dst_Runtime
+if (Test-Path -LiteralPath $Src_Prefabs) {
+  Copy-TreeTo -From $Src_Prefabs -To $Dst_Runtime_Prefabs
+  Copy-Or-Make-FolderMeta -SrcFolder $Src_Prefabs -DstFolder $Dst_Runtime_Prefabs
+}
+Copy-TreeTo -From $Src_Samples -To $Dst_Samples
+Copy-TreeTo -From $Src_Streaming -To $Dst_Streaming
+Copy-Or-Make-FolderMeta -SrcFolder $Src_Streaming -DstFolder $Dst_Streaming
+Copy-TreeTo -From $Src_Tests -To $Dst_Tests
+Copy-Or-Make-FolderMeta -SrcFolder $Src_Tests -DstFolder $Dst_Tests
+Copy-TreeTo -From $Src_UIToolkit -To $Dst_UIToolkit
+Copy-Or-Make-FolderMeta -SrcFolder $Src_UIToolkit -DstFolder $Dst_UIToolkit
+
+$DevUtilMeta = Join-Path $Dst_Editor "Dev Utilities.meta"
+Remove-Item -LiteralPath $DevUtilMeta -Force -ErrorAction SilentlyContinue
+
+$ReadmePath     = Join-Path $PackageRepoPath "README.md"
+$LicensePath    = Join-Path $PackageRepoPath "LICENSE"
+$GitIgnoreSrc   = Join-Path $ProjectRoot ".gitignore"
+$GitAttributes  = Join-Path $ProjectRoot ".gitattributes"
+
+if (Test-Path (Join-Path $ProjectRoot "README.md"))     { Copy-Item (Join-Path $ProjectRoot "README.md")     $ReadmePath     -Force }
+if (Test-Path (Join-Path $ProjectRoot "LICENSE"))    { Copy-Item (Join-Path $ProjectRoot "LICENSE")    $LicensePath    -Force }
+if (Test-Path -LiteralPath $GitIgnoreSrc)  { Copy-Item -LiteralPath $GitIgnoreSrc  -Destination (Join-Path $PackageRepoPath ".gitignore")   -Force }
+if (Test-Path -LiteralPath $GitAttributes) { Copy-Item -LiteralPath $GitAttributes -Destination (Join-Path $PackageRepoPath ".gitattributes") -Force }
+
+foreach ($p in @($ReadmePath,$LicensePath)) { if (Test-Path -LiteralPath $p) { Write-TextMeta $p } }
+
+$PkgJsonPath = Join-Path $PackageRepoPath "package.json"
+if (Test-Path -LiteralPath $PkgJsonPath) {
+  $pkg = Get-Content -LiteralPath $PkgJsonPath -Raw | ConvertFrom-Json
+} else {
+  $pkg = [pscustomobject]@{
+    name        = $PackageName
+    version     = $Version
+    displayName = $DisplayName
+    description = $Description
+    unity       = $UnityVersion
+    unityRelease= $UnityRelease
+    keywords    = @("Webcam","Hand Gesture","Sign language")
+    author      = @{ name = $AuthorName }
+    dependencies= @{
+      "com.gilzoide.sqlite-net"      = "1.2.3"
+      "com.github.homuler.mediapipe" = "0.16.1"
+      "com.unity.ugui"               = "2.0.0"
+      "com.unity.editorcoroutines"   = "1.0.0"
+    }
+    samples     = @(
+      @{ displayName="Sample Menu UI";  description="Contains a sample scene and scripts for a menu UI"; path="Samples~/SampleMenu" },
+      @{ displayName="Sample RollABall"; description="Contains a sample RollABall scene and related scripts"; path="Samples~/Rollaball" }
+    )
+  }
+}
+$pkg.version = $Version
+if ($OverrideCoreMetadata -or -not (Test-Path -LiteralPath $PkgJsonPath)) {
+  $pkg.name         = $PackageName
+  $pkg.displayName  = $DisplayName
+  $pkg.description  = $Description
+  $pkg.unity        = $UnityVersion
+  $pkg.unityRelease = $UnityRelease
+  if (-not $pkg.author) { $pkg | Add-Member -NotePropertyName author -NotePropertyValue @{ name = $AuthorName } }
+  elseif (-not $pkg.author.name) { $pkg.author.name = $AuthorName }
+}
+if ($RebuildSamples) {
+  $samplesRoot = Join-Path $PackageRepoPath "Samples~"
+  $entries = @()
+  if (Test-Path -LiteralPath $samplesRoot) {
+    Get-ChildItem -LiteralPath $samplesRoot -Directory | ForEach-Object {
+      $entries += [pscustomobject]@{ displayName=$_.Name; description=""; path=("Samples~/" + $_.Name) }
+    }
+  }
+  $pkg.samples = $entries
+}
+$pkg | ConvertTo-Json -Depth 20 | Out-File -FilePath $PkgJsonPath -Encoding UTF8
+Write-TextMeta $PkgJsonPath
+
+Push-Location $PackageRepoPath
+git add -A
+if (-not (git diff --cached --quiet)) { git commit -m "Release $Version" | Out-Null } else { Write-Host "No changes to commit." }
+if ($ForceBranch) { git push -u origin $BranchName --force-with-lease | Out-Null } else { git push -u origin $BranchName | Out-Null }
+if ($TagRelease) { git tag -f -a "v$Version" -m "Release $Version" | Out-Null; git push --force origin tag "v$Version" | Out-Null }
+Pop-Location
+
+Write-Host "`n✅ Done."
+Write-Host "Test install via branch:"
+Write-Host "  https://github.com/GYOUDNova/Nova_Package.git#$BranchName"
+if ($TagRelease) {
+  Write-Host "Or via tag:"
+  Write-Host "  https://github.com/GYOUDNova/Nova_Package.git#v$Version"
+}

--- a/pack.ps1
+++ b/pack.ps1
@@ -4,6 +4,7 @@ param(
   [string]$BranchName = "",
   [switch]$ForceBranch,
   [switch]$TagRelease,
+  [switch]$AllowDirty,
   [string]$PackageName    = "com.gyoudnova.handrecognition",
   [string]$DisplayName    = "Hand Recognition",
   [string]$Description    = "This is the package for hand recognition project created by Gyoud Nova",
@@ -26,7 +27,7 @@ $ProjectRoot = & git -C $ScriptDir rev-parse --show-toplevel 2>$null
 if (-not $ProjectRoot) { $ProjectRoot = (Resolve-Path $ScriptDir).Path }
 
 Push-Location $ProjectRoot
-if (git status --porcelain) { Pop-Location; throw "Working tree is not clean." }
+if (-not $AllowDirty -and (git status --porcelain)) { Pop-Location; throw "Working tree is not clean. Use -AllowDirty to bypass." }
 git fetch origin | Out-Null
 git checkout $BaseBranch | Out-Null
 git pull --ff-only | Out-Null
@@ -35,9 +36,6 @@ if ($remoteExists -and -not $ForceBranch) { Pop-Location; throw "Remote branch '
 if ((git branch --list $BranchName)) { git branch -D $BranchName | Out-Null }
 git checkout -B $BranchName $BaseBranch | Out-Null
 Pop-Location
-
-$PackagesRoot = Join-Path $ProjectRoot "Packages"
-$PackagePath  = Join-Path $PackagesRoot $PackageName
 
 function New-Dir([string]$Path) { if (-not (Test-Path -LiteralPath $Path)) { New-Item -ItemType Directory -Force -Path $Path | Out-Null } }
 function Clear-Dir([string]$Path) { if (Test-Path -LiteralPath $Path) { Get-ChildItem -LiteralPath $Path -Force | Remove-Item -Recurse -Force -ErrorAction SilentlyContinue } else { New-Dir $Path } }
@@ -79,7 +77,9 @@ function Copy-TreeTo { param([Parameter(Mandatory=$true)][string]$From,[Paramete
   Get-ChildItem -LiteralPath $From -Force | ForEach-Object { $dest = Join-Path $To $_.Name; Copy-Item -LiteralPath $_.FullName -Destination $dest -Recurse -Force -ErrorAction Stop }
 }
 
-# New-Dir $PackagesRoot
+$PackagesRoot = Join-Path $ProjectRoot "Packages"
+$PackagePath  = Join-Path $PackagesRoot $PackageName
+New-Dir $PackagesRoot
 New-Dir $PackagePath
 
 $Assets               = Join-Path $ProjectRoot "Assets"
@@ -125,6 +125,35 @@ Copy-Or-Make-FolderMeta -SrcFolder $Src_UIToolkit -DstFolder $Dst_UIToolkit
 
 $DevUtilMeta = Join-Path $Dst_Editor "Dev Utilities.meta"
 Remove-Item -LiteralPath $DevUtilMeta -Force -ErrorAction SilentlyContinue
+
+$ReadmePath     = Join-Path $PackagePath "README.md"
+$LicensePath    = Join-Path $PackagePath "LICENSE"
+$GitIgnoreSrc   = Join-Path $ProjectRoot ".gitignore"
+
+if (Test-Path (Join-Path $ProjectRoot "README.md"))     { Copy-Item (Join-Path $ProjectRoot "README.md")     $ReadmePath     -Force }
+if (Test-Path (Join-Path $ProjectRoot "LICENSE"))    { Copy-Item (Join-Path $ProjectRoot "LICENSE")    $LicensePath    -Force }
+if (Test-Path -LiteralPath $GitIgnoreSrc)  { Copy-Item -LiteralPath $GitIgnoreSrc  -Destination (Join-Path $PackagePath ".gitignore") -Force }
+
+$PkgGitAttr = Join-Path $PackagePath ".gitattributes"
+@"
+* -filter -diff -merge -text
+*.png   -filter -diff -merge -text
+*.jpg   -filter -diff -merge -text
+*.jpeg  -filter -diff -merge -text
+*.psd   -filter -diff -merge -text
+*.tga   -filter -diff -merge -text
+*.bmp   -filter -diff -merge -text
+*.exr   -filter -diff -merge -text
+*.wav   -filter -diff -merge -text
+*.mp3   -filter -diff -merge -text
+*.mp4   -filter -diff -merge -text
+*.prefab -filter -diff -merge -text
+*.mat   -filter -diff -merge -text
+*.anim  -filter -diff -merge -text
+*.controller -filter -diff -merge -text
+"@ | Out-File -Encoding ASCII $PkgGitAttr
+
+foreach ($p in @($ReadmePath,$LicensePath)) { if (Test-Path -LiteralPath $p) { Write-TextMeta $p } }
 
 $PkgJsonPath = Join-Path $PackagePath "package.json"
 if (Test-Path -LiteralPath $PkgJsonPath) {
@@ -172,11 +201,12 @@ $pkg | ConvertTo-Json -Depth 20 | Out-File -FilePath $PkgJsonPath -Encoding UTF8
 Write-TextMeta $PkgJsonPath
 
 Push-Location $ProjectRoot
-git add -A
+git add -- "Packages/$PackageName"
 if (-not (git diff --cached --quiet)) { git commit -m "Release $Version" | Out-Null }
 if ($ForceBranch) { git push -u origin $BranchName --force-with-lease | Out-Null } else { git push -u origin $BranchName | Out-Null }
 if ($TagRelease) { git tag -f -a "v$Version" -m "Release $Version" | Out-Null; git push --force origin tag "v$Version" | Out-Null }
 Pop-Location
 
-Write-Host "https://github.com/GYOUDNova/Nova.git?path=/Packages/$PackageName#$BranchName"
-if ($TagRelease) { Write-Host "https://github.com/GYOUDNova/Nova.git?path=/Packages/$PackageName#v$Version" }
+Write-Host "Install via branch:"
+Write-Host "  https://github.com/GYOUDNova/Nova.git?path=/Packages/$PackageName#$BranchName"
+if ($TagRelease) { Write-Host "Install via tag:"; Write-Host "  https://github.com/GYOUDNova/Nova.git?path=/Packages/$PackageName#v$Version" }

--- a/pack.ps1
+++ b/pack.ps1
@@ -126,18 +126,6 @@ Copy-Or-Make-FolderMeta -SrcFolder $Src_UIToolkit -DstFolder $Dst_UIToolkit
 $DevUtilMeta = Join-Path $Dst_Editor "Dev Utilities.meta"
 Remove-Item -LiteralPath $DevUtilMeta -Force -ErrorAction SilentlyContinue
 
-$ReadmePath     = Join-Path $PackagePath "README.md"
-$LicensePath    = Join-Path $PackagePath "LICENSE"
-$GitIgnoreSrc   = Join-Path $ProjectRoot ".gitignore"
-$GitAttributes  = Join-Path $ProjectRoot ".gitattributes"
-
-if (Test-Path (Join-Path $ProjectRoot "README.md"))     { Copy-Item (Join-Path $ProjectRoot "README.md")     $ReadmePath     -Force }
-if (Test-Path (Join-Path $ProjectRoot "LICENSE"))    { Copy-Item (Join-Path $ProjectRoot "LICENSE")    $LicensePath    -Force }
-if (Test-Path -LiteralPath $GitIgnoreSrc)  { Copy-Item -LiteralPath $GitIgnoreSrc  -Destination (Join-Path $PackagePath ".gitignore")   -Force }
-if (Test-Path -LiteralPath $GitAttributes) { Copy-Item -LiteralPath $GitAttributes -Destination (Join-Path $PackagePath ".gitattributes") -Force }
-
-foreach ($p in @($ReadmePath,$LicensePath)) { if (Test-Path -LiteralPath $p) { Write-TextMeta $p } }
-
 $PkgJsonPath = Join-Path $PackagePath "package.json"
 if (Test-Path -LiteralPath $PkgJsonPath) {
   $pkg = Get-Content -LiteralPath $PkgJsonPath -Raw | ConvertFrom-Json

--- a/pack.ps1
+++ b/pack.ps1
@@ -1,6 +1,5 @@
 param(
   [Parameter(Mandatory=$true)][string]$Version,
-  [Parameter(Mandatory=$true)][string]$PackageRepoPath,
   [string]$BaseBranch = "main",
   [string]$BranchName = "",
   [switch]$ForceBranch,
@@ -26,40 +25,24 @@ $ScriptDir   = Split-Path -Parent $MyInvocation.MyCommand.Path
 $ProjectRoot = & git -C $ScriptDir rev-parse --show-toplevel 2>$null
 if (-not $ProjectRoot) { $ProjectRoot = (Resolve-Path $ScriptDir).Path }
 
-if (-not (Test-Path -LiteralPath $PackageRepoPath)) { throw "PackageRepoPath '$PackageRepoPath' not found." }
-$PackageRepoPath = (Resolve-Path -LiteralPath $PackageRepoPath).Path
-
-$projRootN = [IO.Path]::GetFullPath($ProjectRoot + [IO.Path]::DirectorySeparatorChar)
-$destRootN = [IO.Path]::GetFullPath($PackageRepoPath + [IO.Path]::DirectorySeparatorChar)
-if ($destRootN.StartsWith($projRootN, [System.StringComparison]::OrdinalIgnoreCase)) { throw "Package repo '$destRootN' cannot be inside dev repo '$projRootN'." }
-
-Write-Host "==> Packing $PackageName v$Version"
-Write-Host "Dev repo:       $ProjectRoot"
-Write-Host "Package repo:   $PackageRepoPath"
-Write-Host "Base branch:    $BaseBranch"
-Write-Host "Package branch: $BranchName"
-
-if (-not (Test-Path (Join-Path $PackageRepoPath ".git"))) { throw "ERROR: $PackageRepoPath is not a git repo." }
-
-Push-Location $PackageRepoPath
+Push-Location $ProjectRoot
+if (git status --porcelain) { Pop-Location; throw "Working tree is not clean." }
 git fetch origin | Out-Null
 git checkout $BaseBranch | Out-Null
 git pull --ff-only | Out-Null
 $remoteExists = -not [string]::IsNullOrWhiteSpace((git ls-remote --heads origin $BranchName))
-if ($remoteExists -and -not $ForceBranch) { Pop-Location; throw "Remote branch '$BranchName' already exists. Re-run with -ForceBranch to overwrite." }
+if ($remoteExists -and -not $ForceBranch) { Pop-Location; throw "Remote branch '$BranchName' exists. Use -ForceBranch to overwrite." }
 if ((git branch --list $BranchName)) { git branch -D $BranchName | Out-Null }
 git checkout -B $BranchName $BaseBranch | Out-Null
-if (git status --porcelain) { Pop-Location; throw "ERROR: package repo has uncommitted changes." }
-Get-ChildItem -LiteralPath $PackageRepoPath -Force | Where-Object { $_.Name -ne ".git" } | Remove-Item -Recurse -Force -ErrorAction Stop
 Pop-Location
 
+$PackagesRoot = Join-Path $ProjectRoot "Packages"
+$PackagePath  = Join-Path $PackagesRoot $PackageName
+
 function New-Dir([string]$Path) { if (-not (Test-Path -LiteralPath $Path)) { New-Item -ItemType Directory -Force -Path $Path | Out-Null } }
+function Clear-Dir([string]$Path) { if (Test-Path -LiteralPath $Path) { Get-ChildItem -LiteralPath $Path -Force | Remove-Item -Recurse -Force -ErrorAction SilentlyContinue } else { New-Dir $Path } }
 function New-GuidHex { ([guid]::NewGuid().ToString("N")) }
-function Write-FolderMeta([string]$FolderPath) {
-  $metaPath = "$FolderPath.meta"
-  if (Test-Path -LiteralPath $metaPath) { return }
-  $guid = New-GuidHex
-@"
+function Write-FolderMeta([string]$FolderPath) { $metaPath = "$FolderPath.meta"; if (Test-Path -LiteralPath $metaPath) { return }; $guid = New-GuidHex; @"
 fileFormatVersion: 2
 guid: $guid
 folderAsset: yes
@@ -68,13 +51,8 @@ DefaultImporter:
   userData: 
   assetBundleName: 
   assetBundleVariant: 
-"@ | Out-File -FilePath $metaPath -Encoding ascii
-}
-function Write-TextMeta([string]$FilePath) {
-  $metaPath = "$FilePath.meta"
-  if (Test-Path -LiteralPath $metaPath) { return }
-  $guid = New-GuidHex
-@"
+"@ | Out-File -FilePath $metaPath -Encoding ascii }
+function Write-TextMeta([string]$FilePath) { $metaPath = "$FilePath.meta"; if (Test-Path -LiteralPath $metaPath) { return }; $guid = New-GuidHex; @"
 fileFormatVersion: 2
 guid: $guid
 TextScriptImporter:
@@ -82,42 +60,27 @@ TextScriptImporter:
   userData: 
   assetBundleName: 
   assetBundleVariant: 
-"@ | Out-File -FilePath $metaPath -Encoding ascii
-}
-function Copy-Or-Make-FolderMeta([string]$SrcFolder, [string]$DstFolder) {
-  $srcParent = Split-Path -Parent $SrcFolder
-  $srcLeaf   = Split-Path -Leaf $SrcFolder
-  $srcMeta   = Join-Path $srcParent ($srcLeaf + ".meta")
-  $dstMeta   = "$DstFolder.meta"
-  if (Test-Path -LiteralPath $srcMeta) { Copy-Item -LiteralPath $srcMeta -Destination $dstMeta -Force } else { Write-FolderMeta $DstFolder }
-}
+"@ | Out-File -FilePath $metaPath -Encoding ascii }
+function Copy-Or-Make-FolderMeta([string]$SrcFolder, [string]$DstFolder) { $srcParent = Split-Path -Parent $SrcFolder; $srcLeaf = Split-Path -Leaf $SrcFolder; $srcMeta = Join-Path $srcParent ($srcLeaf + ".meta"); $dstMeta = "$DstFolder.meta"; if (Test-Path -LiteralPath $srcMeta) { Copy-Item -LiteralPath $srcMeta -Destination $dstMeta -Force } else { Write-FolderMeta $DstFolder } }
 function Copy-DirContents {
-  param(
-    [Parameter(Mandatory=$true)][string]$From,
-    [Parameter(Mandatory=$true)][string]$To,
-    [string[]]$ExcludeChildNames = @()
-  )
-  if (-not (Test-Path -LiteralPath $From -PathType Container)) { Write-Host "SKIP missing: $From"; return }
+  param([Parameter(Mandatory=$true)][string]$From,[Parameter(Mandatory=$true)][string]$To,[string[]]$ExcludeChildNames=@())
+  if (-not (Test-Path -LiteralPath $From -PathType Container)) { return }
   New-Dir $To
   Get-ChildItem -LiteralPath $From -Force | ForEach-Object {
     if ($ExcludeChildNames -contains $_.Name) { return }
-    if ($_.Extension -ieq ".meta") {
-      $base = [IO.Path]::GetFileNameWithoutExtension($_.Name)
-      if ($ExcludeChildNames -contains $base) { return }
-    }
+    if ($_.Extension -ieq ".meta") { $base = [IO.Path]::GetFileNameWithoutExtension($_.Name); if ($ExcludeChildNames -contains $base) { return } }
     $dest = Join-Path $To $_.Name
     Copy-Item -LiteralPath $_.FullName -Destination $dest -Recurse -Force -ErrorAction Stop
   }
 }
-function Copy-TreeTo {
-  param([Parameter(Mandatory=$true)][string]$From, [Parameter(Mandatory=$true)][string]$To)
-  if (-not (Test-Path -LiteralPath $From -PathType Container)) { Write-Host "SKIP missing: $From"; return }
+function Copy-TreeTo { param([Parameter(Mandatory=$true)][string]$From,[Parameter(Mandatory=$true)][string]$To)
+  if (-not (Test-Path -LiteralPath $From -PathType Container)) { return }
   New-Dir $To
-  Get-ChildItem -LiteralPath $From -Force | ForEach-Object {
-    $dest = Join-Path $To $_.Name
-    Copy-Item -LiteralPath $_.FullName -Destination $dest -Recurse -Force -ErrorAction Stop
-  }
+  Get-ChildItem -LiteralPath $From -Force | ForEach-Object { $dest = Join-Path $To $_.Name; Copy-Item -LiteralPath $_.FullName -Destination $dest -Recurse -Force -ErrorAction Stop }
 }
+
+# New-Dir $PackagesRoot
+New-Dir $PackagePath
 
 $Assets               = Join-Path $ProjectRoot "Assets"
 $Src_Scripts          = Join-Path $Assets "Scripts"
@@ -128,14 +91,22 @@ $Src_Streaming        = Join-Path $Assets "StreamingAssets"
 $Src_Tests            = Join-Path $Assets "Tests"
 $Src_UIToolkit        = Join-Path $Assets "UI Toolkit"
 
-$Dst_Editor           = Join-Path $PackageRepoPath "Editor"
-$Dst_Images           = Join-Path $PackageRepoPath "Images"
-$Dst_Runtime          = Join-Path $PackageRepoPath "Runtime"
+$Dst_Editor           = Join-Path $PackagePath "Editor"
+$Dst_Images           = Join-Path $PackagePath "Images"
+$Dst_Runtime          = Join-Path $PackagePath "Runtime"
 $Dst_Runtime_Prefabs  = Join-Path $Dst_Runtime "Prefabs"
-$Dst_Samples          = Join-Path $PackageRepoPath "Samples~"
-$Dst_Streaming        = Join-Path $PackageRepoPath "StreamingAssets"
-$Dst_Tests            = Join-Path $PackageRepoPath "Tests"
-$Dst_UIToolkit        = Join-Path $PackageRepoPath "UI Toolkit"
+$Dst_Samples          = Join-Path $PackagePath "Samples~"
+$Dst_Streaming        = Join-Path $PackagePath "StreamingAssets"
+$Dst_Tests            = Join-Path $PackagePath "Tests"
+$Dst_UIToolkit        = Join-Path $PackagePath "UI Toolkit"
+
+Clear-Dir $Dst_Editor
+Clear-Dir $Dst_Images
+Clear-Dir $Dst_Runtime
+Clear-Dir $Dst_Samples
+Clear-Dir $Dst_Streaming
+Clear-Dir $Dst_Tests
+Clear-Dir $Dst_UIToolkit
 
 Copy-DirContents -From $Src_Scripts -To $Dst_Editor -ExcludeChildNames @("Dev Utilities")
 Copy-Or-Make-FolderMeta -SrcFolder $Src_Scripts -DstFolder $Dst_Editor
@@ -143,10 +114,7 @@ Copy-TreeTo -From $Src_Images -To $Dst_Images
 Copy-Or-Make-FolderMeta -SrcFolder $Src_Images -DstFolder $Dst_Images
 New-Dir $Dst_Runtime
 Write-FolderMeta $Dst_Runtime
-if (Test-Path -LiteralPath $Src_Prefabs) {
-  Copy-TreeTo -From $Src_Prefabs -To $Dst_Runtime_Prefabs
-  Copy-Or-Make-FolderMeta -SrcFolder $Src_Prefabs -DstFolder $Dst_Runtime_Prefabs
-}
+if (Test-Path -LiteralPath $Src_Prefabs) { Copy-TreeTo -From $Src_Prefabs -To $Dst_Runtime_Prefabs; Copy-Or-Make-FolderMeta -SrcFolder $Src_Prefabs -DstFolder $Dst_Runtime_Prefabs }
 Copy-TreeTo -From $Src_Samples -To $Dst_Samples
 Copy-TreeTo -From $Src_Streaming -To $Dst_Streaming
 Copy-Or-Make-FolderMeta -SrcFolder $Src_Streaming -DstFolder $Dst_Streaming
@@ -158,19 +126,19 @@ Copy-Or-Make-FolderMeta -SrcFolder $Src_UIToolkit -DstFolder $Dst_UIToolkit
 $DevUtilMeta = Join-Path $Dst_Editor "Dev Utilities.meta"
 Remove-Item -LiteralPath $DevUtilMeta -Force -ErrorAction SilentlyContinue
 
-$ReadmePath     = Join-Path $PackageRepoPath "README.md"
-$LicensePath    = Join-Path $PackageRepoPath "LICENSE"
+$ReadmePath     = Join-Path $PackagePath "README.md"
+$LicensePath    = Join-Path $PackagePath "LICENSE"
 $GitIgnoreSrc   = Join-Path $ProjectRoot ".gitignore"
 $GitAttributes  = Join-Path $ProjectRoot ".gitattributes"
 
 if (Test-Path (Join-Path $ProjectRoot "README.md"))     { Copy-Item (Join-Path $ProjectRoot "README.md")     $ReadmePath     -Force }
 if (Test-Path (Join-Path $ProjectRoot "LICENSE"))    { Copy-Item (Join-Path $ProjectRoot "LICENSE")    $LicensePath    -Force }
-if (Test-Path -LiteralPath $GitIgnoreSrc)  { Copy-Item -LiteralPath $GitIgnoreSrc  -Destination (Join-Path $PackageRepoPath ".gitignore")   -Force }
-if (Test-Path -LiteralPath $GitAttributes) { Copy-Item -LiteralPath $GitAttributes -Destination (Join-Path $PackageRepoPath ".gitattributes") -Force }
+if (Test-Path -LiteralPath $GitIgnoreSrc)  { Copy-Item -LiteralPath $GitIgnoreSrc  -Destination (Join-Path $PackagePath ".gitignore")   -Force }
+if (Test-Path -LiteralPath $GitAttributes) { Copy-Item -LiteralPath $GitAttributes -Destination (Join-Path $PackagePath ".gitattributes") -Force }
 
 foreach ($p in @($ReadmePath,$LicensePath)) { if (Test-Path -LiteralPath $p) { Write-TextMeta $p } }
 
-$PkgJsonPath = Join-Path $PackageRepoPath "package.json"
+$PkgJsonPath = Join-Path $PackagePath "package.json"
 if (Test-Path -LiteralPath $PkgJsonPath) {
   $pkg = Get-Content -LiteralPath $PkgJsonPath -Raw | ConvertFrom-Json
 } else {
@@ -206,29 +174,21 @@ if ($OverrideCoreMetadata -or -not (Test-Path -LiteralPath $PkgJsonPath)) {
   elseif (-not $pkg.author.name) { $pkg.author.name = $AuthorName }
 }
 if ($RebuildSamples) {
-  $samplesRoot = Join-Path $PackageRepoPath "Samples~"
   $entries = @()
-  if (Test-Path -LiteralPath $samplesRoot) {
-    Get-ChildItem -LiteralPath $samplesRoot -Directory | ForEach-Object {
-      $entries += [pscustomobject]@{ displayName=$_.Name; description=""; path=("Samples~/" + $_.Name) }
-    }
+  if (Test-Path -LiteralPath $Dst_Samples) {
+    Get-ChildItem -LiteralPath $Dst_Samples -Directory | ForEach-Object { $entries += [pscustomobject]@{ displayName=$_.Name; description=""; path=("Samples~/" + $_.Name) } }
   }
   $pkg.samples = $entries
 }
 $pkg | ConvertTo-Json -Depth 20 | Out-File -FilePath $PkgJsonPath -Encoding UTF8
 Write-TextMeta $PkgJsonPath
 
-Push-Location $PackageRepoPath
+Push-Location $ProjectRoot
 git add -A
-if (-not (git diff --cached --quiet)) { git commit -m "Release $Version" | Out-Null } else { Write-Host "No changes to commit." }
+if (-not (git diff --cached --quiet)) { git commit -m "Release $Version" | Out-Null }
 if ($ForceBranch) { git push -u origin $BranchName --force-with-lease | Out-Null } else { git push -u origin $BranchName | Out-Null }
 if ($TagRelease) { git tag -f -a "v$Version" -m "Release $Version" | Out-Null; git push --force origin tag "v$Version" | Out-Null }
 Pop-Location
 
-Write-Host "`n✅ Done."
-Write-Host "Test install via branch:"
-Write-Host "  https://github.com/GYOUDNova/Nova_Package.git#$BranchName"
-if ($TagRelease) {
-  Write-Host "Or via tag:"
-  Write-Host "  https://github.com/GYOUDNova/Nova_Package.git#v$Version"
-}
+Write-Host "https://github.com/GYOUDNova/Nova.git?path=/Packages/$PackageName#$BranchName"
+if ($TagRelease) { Write-Host "https://github.com/GYOUDNova/Nova.git?path=/Packages/$PackageName#v$Version" }

--- a/pack.ps1
+++ b/pack.ps1
@@ -1,86 +1,86 @@
+<#
+.SYNOPSIS
+Packs the Unity package into Packages/<PackageName>, bumps version, and pushes a release branch (and optional tag).
+
+.DESCRIPTION
+- Copies selected Assets/* folders into Packages/<PackageName>.
+- Generates .meta files for folders/text so Unity won't complain in immutable Packages/.
+- Writes a package-local .gitattributes to avoid Git LFS/text filters breaking binaries.
+- Creates/updates a release branch (default: release-v<Version>) and optionally an annotated tag v<Version>.
+- Stages only Packages/<PackageName>.
+#>
+
 param(
   [Parameter(Mandatory=$true)][string]$Version,
+
   [string]$BaseBranch = "main",
-  [string]$BranchName = "",
-  [switch]$ForceBranch,
-  [switch]$TagRelease,
-  [switch]$AllowDirty,
+  [string]$BranchName = "",          # default: release-v<Version>
+  [switch]$ForceBranch,              # push with --force-with-lease
+  [switch]$TagRelease,               # also create/push tag v<Version>
+
+  # package.json defaults (used when creating a new one or when -OverrideCoreMetadata is set)
   [string]$PackageName    = "com.gyoudnova.handrecognition",
   [string]$DisplayName    = "Hand Recognition",
   [string]$Description    = "This is the package for hand recognition project created by Gyoud Nova",
   [string]$UnityVersion   = "6000.0",
   [string]$UnityRelease   = "39f1",
   [string]$AuthorName     = "Gyoud Nova",
-  [switch]$OverrideCoreMetadata,
-  [switch]$RebuildSamples
+
+  [switch]$OverrideCoreMetadata,     # overwrite name/display/unity/description in package.json
+  [switch]$RebuildSamples            # rebuild samples[] from Samples~ subfolders
 )
 
-$ErrorActionPreference = "Stop"
-if ($Version -match '^[vV](.+)$') { $Version = $Matches[1] }
-if (-not $BranchName -or [string]::IsNullOrWhiteSpace($BranchName)) { $BranchName = "release-v$Version" }
+# -------------------- Setup --------------------
 
-function Require($name) { if (-not (Get-Command $name -ErrorAction SilentlyContinue)) { throw "Missing dependency in PATH: $name" } }
+$ErrorActionPreference = "Stop"
+
+# Accept "v1.2.3" or "1.2.3"
+if ($Version -match '^[vV](.+)$') { $Version = $Matches[1] }
+
+# Keep branch distinct from tag to avoid ambiguity
+if ([string]::IsNullOrWhiteSpace($BranchName)) { $BranchName = "release-v$Version" }
+
+function Require($name) {
+  if (-not (Get-Command $name -ErrorAction SilentlyContinue)) {
+    throw "Missing dependency in PATH: $name"
+  }
+}
 Require git
 
+# Resolve repo root (works from any subfolder)
 $ScriptDir   = Split-Path -Parent $MyInvocation.MyCommand.Path
 $ProjectRoot = & git -C $ScriptDir rev-parse --show-toplevel 2>$null
 if (-not $ProjectRoot) { $ProjectRoot = (Resolve-Path $ScriptDir).Path }
 
+# -------------------- Create/reset release branch --------------------
+
 Push-Location $ProjectRoot
-if (-not $AllowDirty -and (git status --porcelain)) { Pop-Location; throw "Working tree is not clean. Use -AllowDirty to bypass." }
+
+# Require a clean working tree (stash or commit first if needed)
+if (git status --porcelain) {
+  Pop-Location
+  throw "Working tree is not clean."
+}
+
 git fetch origin | Out-Null
 git checkout $BaseBranch | Out-Null
 git pull --ff-only | Out-Null
+
 $remoteExists = -not [string]::IsNullOrWhiteSpace((git ls-remote --heads origin $BranchName))
-if ($remoteExists -and -not $ForceBranch) { Pop-Location; throw "Remote branch '$BranchName' exists. Use -ForceBranch to overwrite." }
+if ($remoteExists -and -not $ForceBranch) {
+  Pop-Location
+  throw "Remote branch '$BranchName' already exists. Re-run with -ForceBranch to update it."
+}
+
 if ((git branch --list $BranchName)) { git branch -D $BranchName | Out-Null }
 git checkout -B $BranchName $BaseBranch | Out-Null
+
 Pop-Location
 
-function New-Dir([string]$Path) { if (-not (Test-Path -LiteralPath $Path)) { New-Item -ItemType Directory -Force -Path $Path | Out-Null } }
-function Clear-Dir([string]$Path) { if (Test-Path -LiteralPath $Path) { Get-ChildItem -LiteralPath $Path -Force | Remove-Item -Recurse -Force -ErrorAction SilentlyContinue } else { New-Dir $Path } }
-function New-GuidHex { ([guid]::NewGuid().ToString("N")) }
-function Write-FolderMeta([string]$FolderPath) { $metaPath = "$FolderPath.meta"; if (Test-Path -LiteralPath $metaPath) { return }; $guid = New-GuidHex; @"
-fileFormatVersion: 2
-guid: $guid
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 
-"@ | Out-File -FilePath $metaPath -Encoding ascii }
-function Write-TextMeta([string]$FilePath) { $metaPath = "$FilePath.meta"; if (Test-Path -LiteralPath $metaPath) { return }; $guid = New-GuidHex; @"
-fileFormatVersion: 2
-guid: $guid
-TextScriptImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 
-"@ | Out-File -FilePath $metaPath -Encoding ascii }
-function Copy-Or-Make-FolderMeta([string]$SrcFolder, [string]$DstFolder) { $srcParent = Split-Path -Parent $SrcFolder; $srcLeaf = Split-Path -Leaf $SrcFolder; $srcMeta = Join-Path $srcParent ($srcLeaf + ".meta"); $dstMeta = "$DstFolder.meta"; if (Test-Path -LiteralPath $srcMeta) { Copy-Item -LiteralPath $srcMeta -Destination $dstMeta -Force } else { Write-FolderMeta $DstFolder } }
-function Copy-DirContents {
-  param([Parameter(Mandatory=$true)][string]$From,[Parameter(Mandatory=$true)][string]$To,[string[]]$ExcludeChildNames=@())
-  if (-not (Test-Path -LiteralPath $From -PathType Container)) { return }
-  New-Dir $To
-  Get-ChildItem -LiteralPath $From -Force | ForEach-Object {
-    if ($ExcludeChildNames -contains $_.Name) { return }
-    if ($_.Extension -ieq ".meta") { $base = [IO.Path]::GetFileNameWithoutExtension($_.Name); if ($ExcludeChildNames -contains $base) { return } }
-    $dest = Join-Path $To $_.Name
-    Copy-Item -LiteralPath $_.FullName -Destination $dest -Recurse -Force -ErrorAction Stop
-  }
-}
-function Copy-TreeTo { param([Parameter(Mandatory=$true)][string]$From,[Parameter(Mandatory=$true)][string]$To)
-  if (-not (Test-Path -LiteralPath $From -PathType Container)) { return }
-  New-Dir $To
-  Get-ChildItem -LiteralPath $From -Force | ForEach-Object { $dest = Join-Path $To $_.Name; Copy-Item -LiteralPath $_.FullName -Destination $dest -Recurse -Force -ErrorAction Stop }
-}
+# -------------------- Paths --------------------
 
 $PackagesRoot = Join-Path $ProjectRoot "Packages"
 $PackagePath  = Join-Path $PackagesRoot $PackageName
-New-Dir $PackagesRoot
-New-Dir $PackagePath
 
 $Assets               = Join-Path $ProjectRoot "Assets"
 $Src_Scripts          = Join-Path $Assets "Scripts"
@@ -95,11 +95,136 @@ $Dst_Editor           = Join-Path $PackagePath "Editor"
 $Dst_Images           = Join-Path $PackagePath "Images"
 $Dst_Runtime          = Join-Path $PackagePath "Runtime"
 $Dst_Runtime_Prefabs  = Join-Path $Dst_Runtime "Prefabs"
-$Dst_Samples          = Join-Path $PackagePath "Samples~"
+$Dst_Samples          = Join-Path $PackagePath "Samples~"       # hidden until user imports
 $Dst_Streaming        = Join-Path $PackagePath "StreamingAssets"
 $Dst_Tests            = Join-Path $PackagePath "Tests"
 $Dst_UIToolkit        = Join-Path $PackagePath "UI Toolkit"
 
+# -------------------- Helpers --------------------
+
+function New-Dir([string]$Path) {
+  if (-not (Test-Path -LiteralPath $Path)) {
+    New-Item -ItemType Directory -Force -Path $Path | Out-Null
+  }
+}
+
+function Clear-Dir([string]$Path) {
+  if (Test-Path -LiteralPath $Path) {
+    Get-ChildItem -LiteralPath $Path -Force | Remove-Item -Recurse -Force -ErrorAction SilentlyContinue
+  } else {
+    New-Dir $Path
+  }
+}
+
+function New-GuidHex { ([guid]::NewGuid().ToString("N")) }
+
+<#
+.SYNOPSIS
+Create a .meta file for a folder if missing.
+#>
+function Write-FolderMeta([string]$FolderPath) {
+  $metaPath = "$FolderPath.meta"
+  if (Test-Path -LiteralPath $metaPath) { return }
+  $guid = New-GuidHex
+  @"
+fileFormatVersion: 2
+guid: $guid
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+"@ | Out-File -FilePath $metaPath -Encoding ascii
+}
+
+<#
+.SYNOPSIS
+Create a .meta file for a text asset if missing (README, package.json, etc.).
+#>
+function Write-TextMeta([string]$FilePath) {
+  $metaPath = "$FilePath.meta"
+  if (Test-Path -LiteralPath $metaPath) { return }
+  $guid = New-GuidHex
+  @"
+fileFormatVersion: 2
+guid: $guid
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+"@ | Out-File -FilePath $metaPath -Encoding ascii
+}
+
+<#
+.SYNOPSIS
+Copy folder root .meta if available (preserves GUID), else synthesize a new one.
+#>
+function Copy-Or-Make-FolderMeta([string]$SrcFolder, [string]$DstFolder) {
+  $srcParent = Split-Path -Parent $SrcFolder
+  $srcLeaf   = Split-Path -Leaf $SrcFolder
+  $srcMeta   = Join-Path $srcParent ($srcLeaf + ".meta")
+  $dstMeta   = "$DstFolder.meta"
+
+  if (Test-Path -LiteralPath $srcMeta) {
+    Copy-Item -LiteralPath $srcMeta -Destination $dstMeta -Force
+  } else {
+    Write-FolderMeta $DstFolder
+  }
+}
+
+<#
+.SYNOPSIS
+Copy the contents of a folder, excluding specific child names and their .meta.
+#>
+function Copy-DirContents {
+  param(
+    [Parameter(Mandatory=$true)][string]$From,
+    [Parameter(Mandatory=$true)][string]$To,
+    [string[]]$ExcludeChildNames = @()
+  )
+
+  if (-not (Test-Path -LiteralPath $From -PathType Container)) { return }
+  New-Dir $To
+
+  Get-ChildItem -LiteralPath $From -Force | ForEach-Object {
+    if ($ExcludeChildNames -contains $_.Name) { return }
+
+    if ($_.Extension -ieq ".meta") {
+      $base = [IO.Path]::GetFileNameWithoutExtension($_.Name)
+      if ($ExcludeChildNames -contains $base) { return }
+    }
+
+    $dest = Join-Path $To $_.Name
+    Copy-Item -LiteralPath $_.FullName -Destination $dest -Recurse -Force -ErrorAction Stop
+  }
+}
+
+<#
+.SYNOPSIS
+Copy an entire directory tree's contents into a destination folder.
+#>
+function Copy-TreeTo {
+  param(
+    [Parameter(Mandatory=$true)][string]$From,
+    [Parameter(Mandatory=$true)][string]$To
+  )
+  if (-not (Test-Path -LiteralPath $From -PathType Container)) { return }
+  New-Dir $To
+
+  Get-ChildItem -LiteralPath $From -Force | ForEach-Object {
+    $dest = Join-Path $To $_.Name
+    Copy-Item -LiteralPath $_.FullName -Destination $dest -Recurse -Force -ErrorAction Stop
+  }
+}
+
+# -------------------- Build package tree --------------------
+
+New-Dir $PackagesRoot
+New-Dir $PackagePath
+
+# Start clean inside the package
 Clear-Dir $Dst_Editor
 Clear-Dir $Dst_Images
 Clear-Dir $Dst_Runtime
@@ -108,32 +233,54 @@ Clear-Dir $Dst_Streaming
 Clear-Dir $Dst_Tests
 Clear-Dir $Dst_UIToolkit
 
+# Editor <- Assets/Scripts  (excluding Dev Utilities)
 Copy-DirContents -From $Src_Scripts -To $Dst_Editor -ExcludeChildNames @("Dev Utilities")
 Copy-Or-Make-FolderMeta -SrcFolder $Src_Scripts -DstFolder $Dst_Editor
+
+# Images <- Assets/Images
 Copy-TreeTo -From $Src_Images -To $Dst_Images
 Copy-Or-Make-FolderMeta -SrcFolder $Src_Images -DstFolder $Dst_Images
+
+# Runtime/Prefabs <- Assets/Prefabs
 New-Dir $Dst_Runtime
 Write-FolderMeta $Dst_Runtime
-if (Test-Path -LiteralPath $Src_Prefabs) { Copy-TreeTo -From $Src_Prefabs -To $Dst_Runtime_Prefabs; Copy-Or-Make-FolderMeta -SrcFolder $Src_Prefabs -DstFolder $Dst_Runtime_Prefabs }
+if (Test-Path -LiteralPath $Src_Prefabs) {
+  Copy-TreeTo -From $Src_Prefabs -To $Dst_Runtime_Prefabs
+  Copy-Or-Make-FolderMeta -SrcFolder $Src_Prefabs -DstFolder $Dst_Runtime_Prefabs
+}
+
+# Samples~ <- Assets/Samples  (no Samples~.meta on purpose)
 Copy-TreeTo -From $Src_Samples -To $Dst_Samples
+
+# StreamingAssets <- Assets/StreamingAssets
 Copy-TreeTo -From $Src_Streaming -To $Dst_Streaming
 Copy-Or-Make-FolderMeta -SrcFolder $Src_Streaming -DstFolder $Dst_Streaming
+
+# Tests <- Assets/Tests
 Copy-TreeTo -From $Src_Tests -To $Dst_Tests
 Copy-Or-Make-FolderMeta -SrcFolder $Src_Tests -DstFolder $Dst_Tests
+
+# UI Toolkit <- Assets/UI Toolkit
 Copy-TreeTo -From $Src_UIToolkit -To $Dst_UIToolkit
 Copy-Or-Make-FolderMeta -SrcFolder $Src_UIToolkit -DstFolder $Dst_UIToolkit
 
+# Remove stray meta for excluded folder if present
 $DevUtilMeta = Join-Path $Dst_Editor "Dev Utilities.meta"
 Remove-Item -LiteralPath $DevUtilMeta -Force -ErrorAction SilentlyContinue
 
+# -------------------- Docs & .gitattributes --------------------
+
 $ReadmePath     = Join-Path $PackagePath "README.md"
 $LicensePath    = Join-Path $PackagePath "LICENSE"
-$GitIgnoreSrc   = Join-Path $ProjectRoot ".gitignore"
 
 if (Test-Path (Join-Path $ProjectRoot "README.md"))     { Copy-Item (Join-Path $ProjectRoot "README.md")     $ReadmePath     -Force }
 if (Test-Path (Join-Path $ProjectRoot "LICENSE"))    { Copy-Item (Join-Path $ProjectRoot "LICENSE")    $LicensePath    -Force }
-if (Test-Path -LiteralPath $GitIgnoreSrc)  { Copy-Item -LiteralPath $GitIgnoreSrc  -Destination (Join-Path $PackagePath ".gitignore") -Force }
 
+foreach ($p in @($ReadmePath,$LicensePath)) {
+  if (Test-Path -LiteralPath $p) { Write-TextMeta $p }
+}
+
+# Disable LFS/text filters for files inside the package
 $PkgGitAttr = Join-Path $PackagePath ".gitattributes"
 @"
 * -filter -diff -merge -text
@@ -152,10 +299,12 @@ $PkgGitAttr = Join-Path $PackagePath ".gitattributes"
 *.anim  -filter -diff -merge -text
 *.controller -filter -diff -merge -text
 "@ | Out-File -Encoding ASCII $PkgGitAttr
+Write-TextMeta $PkgGitAttr
 
-foreach ($p in @($ReadmePath,$LicensePath)) { if (Test-Path -LiteralPath $p) { Write-TextMeta $p } }
+# -------------------- package.json --------------------
 
 $PkgJsonPath = Join-Path $PackagePath "package.json"
+
 if (Test-Path -LiteralPath $PkgJsonPath) {
   $pkg = Get-Content -LiteralPath $PkgJsonPath -Raw | ConvertFrom-Json
 } else {
@@ -180,7 +329,11 @@ if (Test-Path -LiteralPath $PkgJsonPath) {
     )
   }
 }
+
+# Bump version
 $pkg.version = $Version
+
+# Optionally refresh core fields
 if ($OverrideCoreMetadata -or -not (Test-Path -LiteralPath $PkgJsonPath)) {
   $pkg.name         = $PackageName
   $pkg.displayName  = $DisplayName
@@ -190,23 +343,56 @@ if ($OverrideCoreMetadata -or -not (Test-Path -LiteralPath $PkgJsonPath)) {
   if (-not $pkg.author) { $pkg | Add-Member -NotePropertyName author -NotePropertyValue @{ name = $AuthorName } }
   elseif (-not $pkg.author.name) { $pkg.author.name = $AuthorName }
 }
+
+# Optionally rebuild samples list from current Samples~ contents
 if ($RebuildSamples) {
   $entries = @()
   if (Test-Path -LiteralPath $Dst_Samples) {
-    Get-ChildItem -LiteralPath $Dst_Samples -Directory | ForEach-Object { $entries += [pscustomobject]@{ displayName=$_.Name; description=""; path=("Samples~/" + $_.Name) } }
+    Get-ChildItem -LiteralPath $Dst_Samples -Directory | ForEach-Object {
+      $entries += [pscustomobject]@{
+        displayName = $_.Name
+        description = ""
+        path        = ("Samples~/" + $_.Name)
+      }
+    }
   }
   $pkg.samples = $entries
 }
+
 $pkg | ConvertTo-Json -Depth 20 | Out-File -FilePath $PkgJsonPath -Encoding UTF8
 Write-TextMeta $PkgJsonPath
 
+# -------------------- Commit & push --------------------
+
 Push-Location $ProjectRoot
+
+# Stage only the package path
 git add -- "Packages/$PackageName"
-if (-not (git diff --cached --quiet)) { git commit -m "Release $Version" | Out-Null }
-if ($ForceBranch) { git push -u origin $BranchName --force-with-lease | Out-Null } else { git push -u origin $BranchName | Out-Null }
-if ($TagRelease) { git tag -f -a "v$Version" -m "Release $Version" | Out-Null; git push --force origin tag "v$Version" | Out-Null }
+
+if (-not (git diff --cached --quiet)) {
+  git commit -m "Release $Version" | Out-Null
+} else {
+  Write-Host "No changes to commit under Packages/$PackageName."
+}
+
+if ($ForceBranch) {
+  git push -u origin $BranchName --force-with-lease | Out-Null
+} else {
+  git push -u origin $BranchName | Out-Null
+}
+
+if ($TagRelease) {
+  git tag -f -a "v$Version" -m "Release $Version" | Out-Null
+  git push --force origin tag "v$Version" | Out-Null
+}
+
 Pop-Location
 
+# Print install URLs
+Write-Host ""
 Write-Host "Install via branch:"
 Write-Host "  https://github.com/GYOUDNova/Nova.git?path=/Packages/$PackageName#$BranchName"
-if ($TagRelease) { Write-Host "Install via tag:"; Write-Host "  https://github.com/GYOUDNova/Nova.git?path=/Packages/$PackageName#v$Version" }
+if ($TagRelease) {
+  Write-Host "Install via tag:"
+  Write-Host "  https://github.com/GYOUDNova/Nova.git?path=/Packages/$PackageName#v$Version"
+}


### PR DESCRIPTION
This includes the implementation of a powershell script (`pack.ps1`) which replicates the manual work done to generate the Nova package, and instead places it inside the `Packages/com.gyoudnova.handrecognition` folder.  Closes #98

This is useful because we do not have to rely on a single branch that has the package, and instead _include_ the package within our development environment.

The current version of the script creates a new branch based on main, and then pushes the changes to that new branch. You can also ask it to create a tag for versioning.

## How-to Run

### No Tag 
`.\pack.ps1 -Version <num>`

### Force a Branch Push (if the branch already exists)
`.\pack.ps1 -Version <num> -ForceBranch`

### Tag the release
`.\pack.ps1 -Version <num> -TagRelease`

### All-in-one
`.\pack.ps1 -Version <num> -ForceBranch -TagRelease`


## Screenshots

### Command Usage
<img width="1696" height="1267" alt="image" src="https://github.com/user-attachments/assets/ea8e7f8d-6406-421f-83e7-725db75e22bf" />


### Package Installed

Here's a screenshot of the package being installed from a specific branch, and using the path.
<img width="1059" height="560" alt="image" src="https://github.com/user-attachments/assets/18d31e5f-ea24-49b7-bd31-207560c0d7da" />
